### PR TITLE
Arregla clase Heap

### DIFF
--- a/include/Heap.h
+++ b/include/Heap.h
@@ -3,20 +3,23 @@
 #include <vector>
 #include <iostream>
 //#include <>
+//macro to print pointers in hex format
+#define PRINT_POINTER(p) std::showbase << std::hex << reinterpret_cast<uintptr_t>(p) << std::dec
+
 template<class T>
 class Heap
 {
-	std::vector<HeapNode<T>> heap;
+    std::vector<HeapNode<T>> heap;
 
-	int parent(int i) { return (i - 1) / 2; }
-	int left(int i) { return 2 * i + 1; }
-	int right(int i) { return 2 * i + 2; }
+    int parent(int i) { return (i - 1) / 2; }
+    int left(int i) { return 2 * i + 1; }
+    int right(int i) { return 2 * i + 2; }
 
     void heapify_up(int i) {
-       //while (i > 0 && heap[i].GetValue() > heap[parent(i)].GetValue()) {
-            //std::swap(heap[i], heap[parent(i)]);
-            //i = parent(i);
-        //}
+        while (i > 0 && heap[parent(i)].GetValue() < heap[i].GetValue()) {
+            std::swap(heap[i], heap[parent(i)]);
+            i = parent(i);
+        }
     }
 
     void heapify_down(int i) {
@@ -24,7 +27,7 @@ class Heap
         int l = left(i);
         int r = right(i);
 
-        if (l < heap.size() && heap[l].GetValue() > heap[largest].GetValue()) largest = l; 
+        if (l < heap.size() && heap[l].GetValue() > heap[largest].GetValue()) largest = l;
         if (r < heap.size() && heap[r].GetValue() > heap[largest].GetValue()) largest = r;
 
         if (largest != i) {
@@ -35,13 +38,17 @@ class Heap
 
 
 
-public: 
+public:
     Heap() {
-        //heap = new std::vector<HeapNode<T> >();
+        //inicializar heap
+        heap.reserve(10);
+        std::cout << "Heap creado: " << heap.size() << std::endl;
     }
 
     void insert(T element, int val) {
-        HeapNode<T>* hn = new HeapNode<T>(&element, val);
+        HeapNode<T>* hn = new HeapNode<T>(element, val);
+        std::cout << "insertando " << PRINT_POINTER(hn) << std::endl;
+        std::cout << "data: " << PRINT_POINTER(hn->GetData()) << std::endl;
         heap.push_back(*hn);
         heapify_up(heap.size() - 1);
     }
@@ -53,24 +60,41 @@ public:
             std::cout << "heap esta vacía" << std::endl;
             return T();
         }
-        T* top = heap.at(0).GetData();
-        
+        const T* top = heap.at(0).GetData();
+
         heap[0] = heap.back();
         heap.pop_back();
         heapify_down(0);
         return *top;
     }
 
-    int peek() const {
+    const T* peek() const {
         if (heap.empty()) {
-            std::count<<"heap esta vacía" << std::endl;
             return nullptr;
         }
-        return heap.at(0);
+        return heap.at(0).GetData();
     }
 
     bool is_empty() const {
         return heap.empty();
+    }
+
+    //itera en todos los elementos del heap, para debuggear
+    void print() const {
+        std::cout << "Heap contiene: " << heap.size() << "elementos" << std::endl;
+        if (heap.empty())return;
+
+        std::cout << "|INDEX\t" << "|NODEDATA\t" << "|NODEVAL\t" << "|ADDRESS\t" << std::endl;
+        for (size_t i = 0; i < heap.size(); i++)
+        {
+            const T* data = heap[i].GetData();
+            std::cout
+                << i << "\t|"
+                << *data << "\t\t|"
+                << heap[i].GetValue() << "\t\t|"
+                << std::showbase << std::hex << reinterpret_cast<uintptr_t>(data) << std::dec
+                << std::endl;
+        }
     }
 };
 

--- a/include/HeapNode.h
+++ b/include/HeapNode.h
@@ -4,11 +4,11 @@ class HeapNode
 {
 private:
 	int value;
-	T* data;
+	T data;
 public:
-	HeapNode(T* _data, int val) : data(_data), value(val) {}
+	HeapNode(T _data, int val) : data(_data), value(val) {}
 
-	T* GetData() { return data; }
-	int GetValue() { return value; }
+	const T* GetData() const { return &data; }
+	int GetValue() const { return value; }
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -152,39 +152,24 @@ int main()
 	Prop* mesa2 = new Prop("caja", 320, 100, 50, player);
 	gameObjects.push_back(mesa2);
 
-	//Heap
-	Heap<std::string>* warningHeap = new Heap<std::string>();
-	Heap<const char*>* warningH2 = new Heap<const char*>();
-
+	std::cout << "probando el heap" << std::endl;
 	Heap<int>* heapInt = new Heap<int>();
-	heapInt->insert(65427, 2);
-	heapInt->insert(7682, 8);
-	heapInt->insert(12345, 10);
+	heapInt->insert(65427, 13);
+	//std::cout << "insertado " <<  *heapInt->peek() <<  std::endl;
+	heapInt->print();
+	heapInt->insert(7682, 28);
+	heapInt->print();
+	//std::cout << "insertado " << *heapInt->peek() << std::endl;
+	heapInt->insert(12345, 666);
+	heapInt->print();
+	//std::cout << "insertado " << *heapInt->peek() << std::endl;
 
-
-
-	std::string warning1 = "recibiste dano!";
-	const char* cwar1 = "recibiste dano!";
-	warningHeap->insert(warning1, 10);
-	warningH2->insert(cwar1, 10);
-
-	std::string warning2 = "agarraste una moneda!";
-	const char* cwar2 = "agarraste una moneda";
-	warningH2->insert(cwar2, 2);
-	warningHeap->insert(warning2, 2);
-	warningH2->insert("warning3", 3);
-	warningH2->insert("warning4", 4);
-	warningH2->insert("warning5", 5);
-
-	//std::cout << warningH2->extract() << std::endl;
-
-	std::string warning3 = "golpeaste un enemigo!";
-	warningHeap->insert(warning3, 5);
-
-	std::string warning4 = "te estrellaste!";
-	
-	warningHeap->insert(warning4, 12);
-
+	//heap que contiene los mensajes de warning
+	Heap<std::string>* warningHeap = new Heap<std::string>();
+	warningHeap->insert("recibiste dano!", 10);
+	warningHeap->insert("agarraste una moneda!", 2);
+	warningHeap->insert("golpeaste un enemigo!", 5);
+	warningHeap->insert("te estrellaste!", 12);
 	PanelMensaje* warnings = new PanelMensaje(GetScreenWidth() /2 - 60, 120, 50, 2);
 
 	


### PR DESCRIPTION

En la función insert el parámetro element se da por valor. Esto provoca que se haga una copia en una variable local, y como es local, se reutiliza la dirección de memoria, por lo que efectivamente cada que se llama insert se guarda el dato nuevo en la misma posición de memoria. Todos los data de los heapnodes están apuntando a la misma posición de memoria.

Esto se soluciona modificando el constructor de HeapNode recibiendo el parámetro data no por referencia, sino por valor, de tal manera que cada vez se tenga que usar una posición de memoria nueva. Las refactorizaciones necesarias son mínimas para que el código funcione:

Ahora aparece correctamente la string en el panel y al imprimir en consola:

¡Saludos!